### PR TITLE
Added getMatchingKeys().

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -115,6 +115,16 @@ PropertiesFile.prototype.getKeys = function () {
     return keys;
 };
 
+PropertiesFile.prototype.getMatchingKeys = function (matchstr) {
+    var keys = [];
+    for (var key in this.objs) {
+        if (key.search(matchstr) != -1) {
+            keys.push(key);
+        }
+    }
+    return keys;
+};
+
 PropertiesFile.prototype.reset = function () {
     this.objs = {};
 };


### PR DESCRIPTION
I am using java-properties to migrate just a small subset of properties from a large Java .properties file, so found it was useful to have this getMatchingKeys() method. Thanks for the lib, by the way!