### PR TITLE
Fix bug with escaped `:` & `=`

### DIFF
--- a/src/properties.js
+++ b/src/properties.js
@@ -33,7 +33,11 @@ class PropertiesFile {
             }
         } else {
             // the key does not exists
-            this.objs[key] = unescape(JSON.parse('"' + value.replace(new RegExp('"', 'g'), '\\"') + '"'));
+            const escapedValue = value
+              .replace(/"/g, '\\"')   // escape "
+              .replace(/\\:/g, ':')   // remove \ before :
+              .replace(/\\=/g, '=');  // remove \ before =
+            this.objs[key] = unescape(JSON.parse('"' + escapedValue + '"'));
         }
     }
 };
@@ -74,7 +78,7 @@ class PropertiesFile {
     }
     return defaultValue;
 };
-    
+
   getLast(key, defaultValue) {
     if (this.objs.hasOwnProperty(key)) {
         if (Array.isArray(this.objs[key])) {
@@ -86,7 +90,7 @@ class PropertiesFile {
     }
     return defaultValue;
 };
-    
+
   getFirst(key, defaultValue) {
     if (this.objs.hasOwnProperty(key)) {
         if (Array.isArray(this.objs[key])) {
@@ -114,10 +118,10 @@ class PropertiesFile {
     function parseBool(b) {
         return !(/^(false|0)$/i).test(b) && !!b;
     }
-    
+
     let val = this.getLast(key);
     if (!val) { return defaultBooleanValue || false; }
-    else { return parseBool(val); }    
+    else { return parseBool(val); }
 };
 
   set(key, value) {
@@ -165,4 +169,3 @@ let of = function(...args) {
 };
 
 export { PropertiesFile, of };
-

--- a/test/fixtures/teamcity.properties
+++ b/test/fixtures/teamcity.properties
@@ -1,0 +1,2 @@
+teamcity.agent.dotnet.agent_url=http\://localhost\:9090/RPC2
+teamcity.auth.userId=TeamCityBuildId\=673

--- a/test/properties_test.js
+++ b/test/properties_test.js
@@ -144,7 +144,7 @@ exports['properties'] = {
       test.equal('14.47', props.get('extra.property'));
       test.equal('444', props.get('another.property'));
       test.equal('7', props.get('referenced.property'));
-      
+
       // 'value.1' must not be defined cause it is unix.properties file
       test.equal(undefined, props.get('value.1'));
       // add the unix.properties file
@@ -153,7 +153,7 @@ exports['properties'] = {
       test.equal('value 1', props.get('value.1'));
       // and that old values are still there
       test.equal('444', props.get('another.property'));
-      
+
       test.done();
   },
   'array file': function(test) {
@@ -187,11 +187,11 @@ exports['properties'] = {
       props.reset();
       var myFile = new PropertiesFile();
       myFile.of('test/fixtures/example.properties', 'test/fixtures/arrayExample.properties');
-      
+
       var myOtherFile = new PropertiesFile();
       myOtherFile.addFile('test/fixtures/example.properties');
       myOtherFile.addFile('test/fixtures/example2.properties');
-      
+
       test.equal(3, myFile.get('arrayKey').length);
       test.equal(undefined, myFile.get('referenced.property'));
       test.equal('some=value', myOtherFile.get('property.with.equals'));
@@ -238,7 +238,7 @@ exports['properties'] = {
       test.equal(false, myFile.getBoolean('boolean.false2'));
       test.equal(false, myFile.getBoolean('boolean.false3'));
       test.equal(false, myFile.getBoolean('boolean.false4'));
-      
+
       test.equal(false, myFile.getBoolean('boolean.empty', false));
       test.equal(true, myFile.getBoolean('boolean.empty', true));
       test.equal(false, myFile.getBoolean('boolean.empty'));
@@ -307,5 +307,12 @@ exports['properties'] = {
       var str = myFile.get('double.quoted.string');
       test.equal(str, 'The first " and the second " should be replaced. Can we replace " in interpolation ?');
       test.done();
+  },
+  'teamcity unescaped `:` & `=`' : function(test) {
+    test.expect(2);
+    var myFile = new PropertiesFile('test/fixtures/teamcity.properties');
+    test.equal(myFile.get('teamcity.agent.dotnet.agent_url'), 'http://localhost:9090/RPC2');
+    test.equal(myFile.get('teamcity.auth.userId'), 'TeamCityBuildId=673');
+    test.done();
   }
 };


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/pvdlg/env-ci/issues/11) parsing fails with:
`SyntaxError: Unexpected token : in JSON` or `SyntaxError: Unexpected token = in JSON`
for TeamCity properties, such as:
```
teamcity.agent.dotnet.agent_url=http\://localhost\:9090/RPC2
teamcity.auth.userId=TeamCityBuildId\=673
```