### PR TITLE
interpolate properties with dash and underscore correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ class PropertiesFile {
     let me = this;
     return s
       .replace(/\\\\/g, '\\')
-      .replace(/\$\{([A-Za-z0-9\.]*)\}/g, function(match) {
+      .replace(/\$\{([A-Za-z0-9\.\-\_]*)\}/g, function(match) {
         return me.getLast(match.substring(2, match.length - 1))!;
       });
   }


### PR DESCRIPTION
Currently interpolate will ignore properties like this:

this-is-my-project-name=value
this_is_my_project_name=value

