### PR TITLE
add: use '=' or ':' as separator when reading properties file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,11 @@ class PropertiesFile {
 
   makeKeys(line: string) {
     if (line && line.indexOf('#') !== 0) {
-      let splitIndex = line.indexOf('=');
+      //let splitIndex = line.indexOf('=');
+      let separatorPositions = ['=',':']
+        .map((sep) => {return line.indexOf(sep);})
+        .filter((index) => {return index > -1;});
+      let splitIndex = Math.min(...separatorPositions);
       let key = line.substring(0, splitIndex).trim();
       let value = line.substring(splitIndex + 1).trim();
       // if keys already exists ...


### PR DESCRIPTION
Does not address whitespace as separator (mentioned in #20) or an escaped separator character in a key, but works for simple properties files.